### PR TITLE
Implemented mobile responsiveness for Board page (1 column for mobile, 3 for desktop)

### DIFF
--- a/src/components/board/CardMapping.tsx
+++ b/src/components/board/CardMapping.tsx
@@ -4,7 +4,7 @@ import Card from "@/components/board/Card";
 const CardMapping = () => {
   return (
     <div className="flex flex-col items-center justify-center p-10">
-      <div className="grid grid-cols-3 gap-x-20">
+      <div className="grid grid-cols-1 gap-x-20 md:grid-cols-3">
         {boardMembers.map(({ name, role, image }, index) => (
           <Card key={index} name={name} role={role} image={image} />
         ))}


### PR DESCRIPTION
Cards for Board members appear in a 3-column wide grid on desktop and 1-column wide grid on mobile.
<img width="1843" height="895" alt="image" src="https://github.com/user-attachments/assets/f13adc9f-1602-4a1a-a9c7-98871f3dff28" />
<img width="543" height="867" alt="image" src="https://github.com/user-attachments/assets/44efdc50-13ff-43dd-b46d-9bf2d32a5acc" />
