### PR TITLE
Additional text added to footer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,6 +19,7 @@
   --color-tsu-brown-100: #d09f8e;
   --color-tsu-brown-300: #8b4e39;
   --color-tsu-brown-400: #784736;
+  --color-tsu-gray-100: #444444;
 
   --font-tsu-sahitya: "Sahitya", serif;
   --font-tsu-sora: "Sora", serif;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -13,8 +13,14 @@ const Footer = () => {
         className="mt-5 flex w-25 sm:mt-0 sm:w-[12%]"
       />
 
-      <div className="font-tsu-sahitya flex text-3xl md:text-4xl lg:text-5xl 2xl:text-6xl">
-        Thai Student Union
+      <div className="flex flex-col items-center gap-2">
+        <div className="font-tsu-sahitya flex text-3xl md:text-4xl lg:text-5xl 2xl:text-6xl">
+          Thai Student Union
+        </div>
+
+        <div className="font-tsu-sahitya text-1xl text-tsu-gray-100 flex">
+          © ACM at UCR 2025. Made with 🧡 from ACM Spark.
+        </div>
       </div>
 
       <div className="invisible border-1 border-black sm:visible sm:h-20 md:ml-2 lg:ml-10"></div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -18,7 +18,7 @@ const Footer = () => {
           Thai Student Union
         </div>
 
-        <div className="font-tsu-sahitya text-sm text-tsu-gray-100 flex">
+        <div className="font-tsu-sahitya text-tsu-gray-100 flex text-sm">
           © ACM at UCR 2025. Made with 🧡 from ACM Spark.
         </div>
       </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -18,7 +18,7 @@ const Footer = () => {
           Thai Student Union
         </div>
 
-        <div className="font-tsu-sahitya text-1xl text-tsu-gray-100 flex">
+        <div className="font-tsu-sahitya text-sm text-tsu-gray-100 flex">
           © ACM at UCR 2025. Made with 🧡 from ACM Spark.
         </div>
       </div>

--- a/src/components/about/aboutbottom.tsx
+++ b/src/components/about/aboutbottom.tsx
@@ -18,7 +18,7 @@ const AboutBottom = () => {
         <Image
           src={elephant}
           alt="Elephant w/Text Bubble Image"
-          className="-mb-30 ml-85 flex w-[70%]"
+          className="-mb-33 ml-85 flex w-[70%]"
         />
       </div>
     </>


### PR DESCRIPTION
Added "© ACM at UCR 2025. Made with 🧡 from ACM & TSU" as small text to the footer.

<img width="1433" height="246" alt="image" src="https://github.com/user-attachments/assets/90452777-74ef-488e-b5cc-9daed8cba3f5" />

<img width="358" height="717" alt="image" src="https://github.com/user-attachments/assets/0f632749-1042-4551-91cb-6aced1b30d0a" />

Properly formatted for both desktop and mobile.